### PR TITLE
Keep config.build.rollupOptions

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -66,6 +66,7 @@ export default (virtualHtmlOptions: PluginOptions): Plugin => {
         config.build = {
           ...config.build,
           rollupOptions: {
+            ...config.build.rollupOptions,
             input: {
               ...extractHtmlPath(pages),
             },

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -66,8 +66,9 @@ export default (virtualHtmlOptions: PluginOptions): Plugin => {
         config.build = {
           ...config.build,
           rollupOptions: {
-            ...config.build.rollupOptions,
+            ...config.build?.rollupOptions,
             input: {
+              ...(config.build?.rollupOptions?.input as object),
               ...extractHtmlPath(pages),
             },
           },


### PR DESCRIPTION
Hi @windsonR , thx for this nice plugin!

This is my PR for issue #15 

I am using your plugin and I try to remove the hashes from the generated files via [rollupOptions](https://vitejs.dev/config/#build-rollupoptions) but noticed that it does not work with this plugin.

This is an example `vite.config.ts`:
``` js
// vite.config.ts
export default defineConfig({
  build: {
    rollupOptions: {
      output: {
        entryFileNames: '[name].js',
      }
   }
   ...
  plugins: [
    ...
    virtualHtml({
       pages: { index: 'index.hbs', page1: 'page1.hbs' }
    }),
  ]
}
```
In the PR I spread the rollupOptions and the rollupOptions.input back into the config.

