### PR TITLE
take vite.config root option into account

### DIFF
--- a/src/buildUtils.ts
+++ b/src/buildUtils.ts
@@ -1,4 +1,5 @@
 import {cwd, VirtualHtmlPage} from './types'
+import { normalizePath } from 'vite'
 
 /**
  * use pages' key as html name
@@ -17,6 +18,19 @@ export function extractHtmlPath(pages: { [p: string]: VirtualHtmlPage }) {
  * @param id
  */
 export function getHtmlName(id:string, root?:string){
+  const _root = (root ?? '').replace(cwd, '');
   const _id = id.replace(cwd, '');
-  return _id.substring(1,_id.length-5).replace(root ?? '', '');
+  const result = _id.substring(0, _id.length - '.html'.length).replace(_root !== '' ? addTrailingSlash(_root) : '', '');
+  return result.startsWith('/') ? result.substring(1) : result;
+
+}
+
+/**
+ * add trailing slash on path
+ * @param {string} path
+ * @returns {string}
+ */
+export function addTrailingSlash(path:string):string {
+  const _path = normalizePath(path.replace(cwd, ''));
+  return _path.endsWith('/') ? _path : `${_path}/`;
 }

--- a/src/buildUtils.ts
+++ b/src/buildUtils.ts
@@ -16,6 +16,7 @@ export function extractHtmlPath(pages: { [p: string]: VirtualHtmlPage }) {
  * get html file's name
  * @param id
  */
-export function getHtmlName(id:string){
-  return id.replace(cwd, '').substring(1,id.replace(cwd, '').length-5)
+export function getHtmlName(id:string, root?:string){
+  const _id = id.replace(cwd, '');
+  return _id.substring(1,_id.length-5).replace(root ?? '', '');
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2,7 +2,7 @@
 import {normalizePath, Plugin, UserConfig, ViteDevServer} from 'vite'
 import {cwd, Pages, PluginOptions} from './types'
 import {generatePageOptions, generateUrl, readHtml} from './devUtils'
-import {extractHtmlPath, getHtmlName} from './buildUtils'
+import {addTrailingSlash, extractHtmlPath, getHtmlName} from './buildUtils'
 import path from 'path'
 import fs, {promises as fsp} from 'fs'
 import {findAllHtmlInProject} from './utils'
@@ -55,7 +55,7 @@ export default (virtualHtmlOptions: PluginOptions): Plugin => {
         // copy all html which is not under project root
         for (const [key, value] of allPage) {
           const pageOption = await generatePageOptions(value, globalData, globalRender)
-          const vHtml = path.resolve(cwd, `./${config.root ?? ''}${key}.html`)
+          const vHtml = path.resolve(cwd, `./${config.root ? addTrailingSlash(config.root) : ''}${key}.html`)
           if (!fs.existsSync(vHtml)) {
             needRemove.push(vHtml)
             await fsp.copyFile(path.resolve(cwd, `.${pageOption.template}`), vHtml)


### PR DESCRIPTION
HI @windsonR, again thx for this plugin!

I use vite.config [`root`](https://vitejs.dev/config/#root) option in my work and created an [example project](https://github.com/djpogo/vite-plugin-virtual-html-example) to demonstrate my usecase.

`npm run build` fails in my example project, by two problems:
* the template file resolution fails
* the `getHtmlName()` does not strip the `root` path

This PR solves "my" usecase, I hope it does not interfer with other project setups.