### PR TITLE
Fix sourcemap support

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -63,7 +63,7 @@ export default (virtualHtmlOptions: PluginOptions): Plugin => {
         })
       }
     },
-    async transform(code: string, id: string): Promise<string> {
+    async transform(code: string, id: string): Promise<string> | null {
       if (id.indexOf('.html') >= 0) {
         const ids = id.split('/')
         const key = ids[ids.length - 1]

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -74,7 +74,7 @@ export default (virtualHtmlOptions: PluginOptions): Plugin => {
           return generateInjectCode(injectCode[DEFAULT_INJECTCODE_ALL], code)
         }
       }
-      return code
+      return null
     },
     // @ts-ignore
     async config(config, {command}) {


### PR DESCRIPTION
I have a problem enabling sourcemap at building. The sourcemap files are not generated properly, and console prints warnings like:

```
> vite build

  vite-plugin-virtual-html [vite-plugin-virtual-html]: This plugin cannot use in library mode! +0ms
vite v4.0.4 building for production...
✓ 28 modules transformed.
rendering chunks (1)...Sourcemap is likely to be incorrect: a plugin (vite-plugin-virtual-html) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
Sourcemap is likely to be incorrect: a plugin (vite-plugin-virtual-html) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
rendering chunks (2)...Sourcemap is likely to be incorrect: a plugin (vite-plugin-virtual-html) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
Sourcemap is likely to be incorrect: a plugin (vite-plugin-virtual-html) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
rendering chunks (3)...Sourcemap is likely to be incorrect: a plugin (vite-plugin-virtual-html) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
Sourcemap is likely to be incorrect: a plugin (vite-plugin-virtual-html) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
Sourcemap is likely to be incorrect: a plugin (vite-plugin-virtual-html) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
Sourcemap is likely to be incorrect: a plugin (vite-plugin-virtual-html) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
Sourcemap is likely to be incorrect: a plugin (vite-plugin-virtual-html) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
Sourcemap is likely to be incorrect: a plugin (vite-plugin-virtual-html) was used to transform files, but didn't generate a sourcemap for the transformation. Consult the plugin documentation for help
```

And the sourcemap files are empty:
```json
{"version":3,"file":"admin.js","sources":[],"sourcesContent":[],"names":[],"mappings":""}
```

This PR fixes it, no warning and sourcemap files are correct.